### PR TITLE
Fix BA-63 - set default and autoselect in add provider modal

### DIFF
--- a/resources/js/vue/components/Modals/bank-modal-add-provider.vue
+++ b/resources/js/vue/components/Modals/bank-modal-add-provider.vue
@@ -7,11 +7,12 @@
         <template v-slot:modal-body>
             <form id="add-provider-form">
                 <div class="mb-3">
-                    <label for="provider-name" class="form-label">Provider Name</label>
+                    <label for="bank-modal-add-provider-name" class="form-label">Provider Name</label>
                     <input
                         type="text"
                         class="form-control"
-                        id="provider-name"
+                        id="bank-modal-add-provider-name"
+                        name="bank-modal-add-provider-name"
                         aria-describedby="provider-name-help"
                         placeholder="eg Asda"
                         v-model="providerName"
@@ -20,10 +21,11 @@
                 </div>
 
                 <div class="mb-3">
-                    <label for="text-entries" class="form-text">Text Entries</label>
+                    <label for="bank-modal-add-provider-text-entries" class="form-text">Text Entries</label>
                     <textarea
                         class="form-control"
-                        id="text-entries"
+                        id="bank-modal-add-provider-text-entries"
+                        name="bank-modal-add-provider-text-entries"
                         aria-describedby="text-entries-help"
                         placeholder="eg Halifax Mortgage"
                         v-model="textEntries"
@@ -32,21 +34,22 @@
                 </div>
 
                 <div class="mb-3">
-                    <label for="remarks" class="form-label">Remarks</label>
+                    <label for="bank-modal-add-provider-remarks" class="form-label">Remarks</label>
                     <input
                         type="text"
                         class="form-control"
-                        id="remarks"
+                        id="bank-modal-add-provider-remarks"
                         v-model="remarks"
                     >
                     <div id="remarks-help" class="form-text">Is there anything you want to add about this provider?</div>
                 </div>
 
                 <div class="mb-3">
-                    <label for="payment-method" class="form-label">Preferred Payment Method</label>
+                    <label for="bank-modal-add-provider-payment-method" class="form-label">Preferred Payment
+                        Method</label>
                     <select
                         class="form-control"
-                        id="payment-method"
+                        id="bank-modal-add-provider-payment-method"
                         name="payment-method"
                         v-model="paymentMethod"
                     >
@@ -171,7 +174,7 @@ export default {
             this.providerName = '';
             this.remarks = '';
             this.textEntries = '';
-            this.paymentMethod = '---';
+            this.paymentMethod = 1;
             this.enableSubmitButton();
         },
         showSimilar: function (similar, providerId) {

--- a/resources/js/vue/components/provider-select.vue
+++ b/resources/js/vue/components/provider-select.vue
@@ -31,7 +31,7 @@
 export default {
     name: "provider-select",
     props: [
-        'transaction_id',
+        'transaction',
         'simple_list'
     ],
     data: function () {
@@ -53,9 +53,13 @@ export default {
             return state;
         },
         showNewProviderModal: function() {
-            this.$store.commit('updateModalTransactionId', this.transaction_id);
+            this.$store.commit('updateModalTransactionId', this.transaction.id);
             window.addProviderModal.show();
             const providerModalEl = document.getElementById('add-provider-modal');
+            document.getElementById('bank-modal-add-provider-name').value = this.transaction.entry;
+            document.getElementById('bank-modal-add-provider-text-entries').value = this.transaction.entry;
+            document.getElementById('bank-modal-add-provider-remarks').value = '';
+            document.getElementById('bank-modal-add-provider-payment-method').value = '1';
             providerModalEl.addEventListener('hidden.bs.modal', (event) => {
                 if (null !== this.$store.state.newEntityDetails) {
                     const newProvider = this.$store.state.newEntityDetails;
@@ -65,15 +69,19 @@ export default {
                     this.$store.commit('updateNewEntityDetails', null);
                 }
             });
+            providerModalEl.addEventListener('shown.bs.modal', (event) => {
+                document.getElementById('bank-modal-add-provider-name').select();
+                document.getElementById('bank-modal-add-provider-name').focus();
+            });
         },
-        async chooseProvider (event) {
+        async chooseProvider(event) {
             if (event.target.value === 'add-new') {
                 this.showNewProviderModal();
                 return;
             }
             this.isDisabled(true);
             let provider_id = this.providerSelected;
-            let url = `/transactions/${this.transaction_id}/update_provider/${provider_id}`;
+            let url = `/transactions/${this.transaction.id}/update_provider/${provider_id}`;
 
             const returnedData = await axios.get(url);
             this.$emit('provider-updated', returnedData.data[0]);

--- a/resources/js/vue/components/td-provider.vue
+++ b/resources/js/vue/components/td-provider.vue
@@ -2,7 +2,7 @@
     <div v-on:dblclick="showProviderSelectBox">
         <slot>
             <provider-select
-                :transaction_id="transaction_id"
+                :transaction="transaction"
                 v-on:provider-updated="providerUpdated"
                 v-if="!read_only"
             ></provider-select>
@@ -14,7 +14,7 @@
 export default {
     name: "td-provider",
     props: [
-        'transaction_id',
+        'transaction',
         'read_only'
     ],
     methods: {

--- a/resources/js/vue/components/transaction-table-row.vue
+++ b/resources/js/vue/components/transaction-table-row.vue
@@ -8,12 +8,12 @@
         <td>
             <td-provider
                 v-if="row.provider.name === 'N/A'"
-                :transaction_id="row.id"
+                :transaction="row"
             ></td-provider>
 
             <td-provider
                 v-else
-                :transaction_id="row.id"
+                :transaction="row"
                 v-on:db-click="dbClickProvider"
             >{{ row.provider.name }}</td-provider>
         </td>


### PR DESCRIPTION
The add provider modal now adds as default, the transaction entry to the name and text-entries (regex) fields, and it auto selects the value from the name field, this means that the name can be changed straight away